### PR TITLE
add GetAPIConfig

### DIFF
--- a/builder/APIBuilder.go
+++ b/builder/APIBuilder.go
@@ -98,14 +98,8 @@ func (builder *APIBuilder) ApiPassphrase(apiPassphrase string) (_builder *APIBui
 	return builder
 }
 
-func (builder *APIBuilder) GetAPIConfig() *APIConfig {
-	return &APIConfig{
-		HttpClient:    builder.client,
-		ApiKey:        builder.apiKey,
-		ApiSecretKey:  builder.secretkey,
-		ApiPassphrase: builder.apiPassphrase,
-		ClientId:      builder.clientId,
-	}
+func (builder *APIBuilder) GetHttpClient() *http.Client {
+	return builder.client
 }
 
 func (builder *APIBuilder) Build(exName string) (api API) {

--- a/builder/APIBuilder.go
+++ b/builder/APIBuilder.go
@@ -98,6 +98,16 @@ func (builder *APIBuilder) ApiPassphrase(apiPassphrase string) (_builder *APIBui
 	return builder
 }
 
+func (builder *APIBuilder) GetAPIConfig() *APIConfig {
+	return &APIConfig{
+		HttpClient:    builder.client,
+		ApiKey:        builder.apiKey,
+		ApiSecretKey:  builder.secretkey,
+		ApiPassphrase: builder.apiPassphrase,
+		ClientId:      builder.clientId,
+	}
+}
+
 func (builder *APIBuilder) Build(exName string) (api API) {
 	var _api API
 	switch exName {


### PR DESCRIPTION
APIBuilder添加GetAPIConfig方法，使得可以复用APIBuild的功能来初始化Custom的API
```golang
apiBuilder := builder.NewAPIBuilder().HttpTimeout(5).HttpProxy("http://127.0.0.1:1080")
api := NewMyCustomAPI(apiBuilder.GetAPIConfig())
```