### PR TITLE
Okexv3

### DIFF
--- a/Const.go
+++ b/Const.go
@@ -77,7 +77,7 @@ type OrderType int
 
 func (ot OrderType) String() string {
 	if ot > 0 && int(ot) <= len(orderTypeSymbol) {
-		return orderTypeSymbol[ot - 1]
+		return orderTypeSymbol[ot-1]
 	}
 	return fmt.Sprintf("UNKNOWN_ORDER_TYPE(%d)", ot)
 }
@@ -87,9 +87,10 @@ var orderTypeSymbol = [...]string{"LIMIT", "MARKET", "FAK", "IOC", "POST_ONLY"}
 const (
 	ORDER_TYPE_LIMIT = 1 + iota
 	ORDER_TYPE_MARKET
+	ORDER_TYPE_FOK
 	ORDER_TYPE_FAK
-	ORDER_TYPE_IOC
 	ORDER_TYPE_POST_ONLY
+	ORDER_TYPE_IOC = ORDER_TYPE_FAK
 )
 
 var (

--- a/okcoin/OKEx_V3.go
+++ b/okcoin/OKEx_V3.go
@@ -896,8 +896,8 @@ func (okv3 *OKExV3) GetFinishedFutureOrders(currencyPair CurrencyPair, contractT
 var OKexOrderTypeMap = map[int]int{
 	ORDER_TYPE_LIMIT:     0,
 	ORDER_TYPE_POST_ONLY: 1,
-	ORDER_TYPE_FAK:       2,
-	ORDER_TYPE_IOC:       3,
+	ORDER_TYPE_FOK:       2,
+	ORDER_TYPE_FAK:       3,
 }
 
 func (okv3 *OKExV3) PlaceFutureOrder2(currencyPair CurrencyPair, contractType, price, amount string, orderType, openType, matchPrice, leverRate int) (string, error) {

--- a/okcoin/OKEx_V3.go
+++ b/okcoin/OKEx_V3.go
@@ -1,7 +1,6 @@
 package okcoin
 
 import (
-	"regexp"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -76,7 +76,7 @@ type futureContract struct {
 
 var tail_zero_re = regexp.MustCompile("0+$")
 
-func normalizeByIncrement(num float64, increment string) (string, error){
+func normalizeByIncrement(num float64, increment string) (string, error) {
 	precision := 0
 	i := strings.Index(increment, ".")
 	// increment is decimal
@@ -85,7 +85,7 @@ func normalizeByIncrement(num float64, increment string) (string, error){
 		trimTailZero := tail_zero_re.ReplaceAllString(decimal, "")
 		precision = len(trimTailZero)
 		return fmt.Sprintf("%."+fmt.Sprintf("%df", precision), num), nil
-	} 
+	}
 	// increment is int
 	incrementInt, err := strconv.ParseInt(increment, 10, 64)
 	if err != nil {
@@ -841,9 +841,22 @@ func (okv3 *OKExV3) GetFutureOrdersByIDsAndState(orderIDs []string, state string
 	postData := url.Values{}
 	if len(orderIDs) > 0 {
 		sort.Strings(orderIDs)
-		// 设计api像cxk, from 参数对应的订单竟然不包含在查询结果中
-		// postData.Set("from", orderIDs[len(orderIDs) - 1])
-		postData.Set("to", orderIDs[0])
+		if contractType == SWAP_CONTRACT {
+			// 设计api像cxk, from 参数对应的订单竟然不包含在查询结果中
+			to, _ := strconv.ParseInt(orderIDs[0], 10, 64)
+			// to = to - 1
+			postData.Set("to", fmt.Sprintf("%d", to))
+			// from, _ := strconv.ParseInt(orderIDs[len(orderIDs) - 1], 10, 64)
+			// from = from + 1
+			// postData.Set("from", fmt.Sprintf("%d", from))
+		} else {
+			before, _ := strconv.ParseInt(orderIDs[0], 10, 64)
+			before = before - 1
+			postData.Set("before", fmt.Sprintf("%d", before))
+			after, _ := strconv.ParseInt(orderIDs[len(orderIDs)-1], 10, 64)
+			after = after + 1
+			postData.Set("after", fmt.Sprintf("%d", after))
+		}
 	}
 	postData.Set("state", state)
 
@@ -1259,7 +1272,7 @@ func (okv3 *OKExV3) getKlineRecords(contractType string, currencyPair CurrencyPa
 			switch i {
 			case 0:
 				r.Timestamp, _ = timeStringToInt64(e.(string)) //to unix timestramp
-				r.Timestamp = r.Timestamp / 1000 // Timestamp in kline is seconds not miliseconds
+				r.Timestamp = r.Timestamp / 1000               // Timestamp in kline is seconds not miliseconds
 			case 1:
 				r.Open, _ = strconv.ParseFloat(e.(string), 64)
 			case 2:

--- a/okcoin/OKEx_V3_Future_Ws.go
+++ b/okcoin/OKEx_V3_Future_Ws.go
@@ -48,7 +48,7 @@ func NewOKExV3FutureWs(contractIDProvider IContractIDProvider) *OKExV3FutureWs {
 	okV3Ws.loginLock = &sync.Mutex{}
 	okV3Ws.authoriedSubs = make([]map[string]interface{}, 0)
 	okV3Ws.WsBuilder = NewWsBuilder().
-		WsUrl("wss://real.okex.com:10440/ws/v3").
+		WsUrl("wss://real.okex.com:10442/ws/v3").
 		Heartbeat([]byte("ping"), 30*time.Second).
 		ReconnectIntervalTime(24 * time.Hour).
 		UnCompressFunc(FlateUnCompress).

--- a/okcoin/OKEx_V3_test.go
+++ b/okcoin/OKEx_V3_test.go
@@ -182,10 +182,9 @@ func TestOKEV3_GetContractValue(t *testing.T) {
 }
 
 func isEqualDiff(klines []FutureKline, seconds int64) bool {
-	miliseconds := seconds * 1000
 	for i := 0; i < len(klines) - 1; i ++ {
 		diff := klines[i + 1].Timestamp-klines[i].Timestamp
-		if diff != miliseconds {
+		if diff != seconds {
 			return false
 		}
 	}

--- a/websocket.go
+++ b/websocket.go
@@ -237,7 +237,7 @@ func (ws *WsConn) checkStatusTimer() {
 
 func (ws *WsConn) HeartbeatTimer() {
 	log.Println("heartbeat interval time =  ", ws.HeartbeatIntervalTime)
-	if ws.HeartbeatIntervalTime == 0 {
+	if ws.HeartbeatIntervalTime == 0 || ws.HeartbeatData == nil {
 		return
 	}
 


### PR DESCRIPTION
## OKEx_V3
1. 修复了okexv3 中FAK(IOC)订单和FOK订单弄混的问题，
2. 修复了okexv3 websocket 默认连接url错误的问题，
3. 修复了okexv3 kline数据中的Timestamp是seconds而非milliseconds的问题
4. 修复了okexv3 下单前利用tickSize和lotSize对price和amount取整的问题，之前的取整处理精度有误。

## websocket
5. websocket的wsbuilder中，如果HeartbeatFunc和HeartbeatData都是nil时，则退出HeartbeatTimer函数，不再发送心跳。主要用于只支持server端心跳的websocket，如hbdm。使用server端心跳时，需要设置一个非0的HeartbeatIntervalTime来启用checkStatusTimer，以定期检查心跳是否超时，但不需要主动定时发送心跳。原来的逻辑中，只要HeartbeatIntervalTime非0，就会定时发动心跳。