### PR TITLE
修复BinanceWs.SubscribeDepth方法，深度数据解析错误bug，导致没有深度数据

### DIFF
--- a/binance/BinanceWs.go
+++ b/binance/BinanceWs.go
@@ -92,7 +92,7 @@ func (bnWs *BinanceWs) SetCallbacks(
 	bnWs.klineCallback = klineCallback
 }
 
-func (bnWs *BinanceWs) subscribe(endpoint string, handle func(msg []byte) error) {
+func (bnWs *BinanceWs) Subscribe(endpoint string, handle func(msg []byte) error) {
 	wsConn := NewWsBuilder().
 		WsUrl(endpoint).
 		AutoReconnect().
@@ -121,9 +121,9 @@ func (bnWs *BinanceWs) SubscribeDepth(pair CurrencyPair, size int) error {
 
 	handle := func(msg []byte) error {
 		rawDepth := struct {
-			LastUpdateID int64           `json:"lastUpdateId"`
-			Bids         [][]interface{} `json:"bids"`
-			Asks         [][]interface{} `json:"asks"`
+			LastUpdateID int64           `json:"T"`
+			Bids         [][]interface{} `json:"b"`
+			Asks         [][]interface{} `json:"a"`
 		}{}
 
 		err := json.Unmarshal(msg, &rawDepth)
@@ -137,7 +137,7 @@ func (bnWs *BinanceWs) SubscribeDepth(pair CurrencyPair, size int) error {
 		bnWs.depthCallback(depth)
 		return nil
 	}
-	bnWs.subscribe(endpoint, handle)
+	bnWs.Subscribe(endpoint, handle)
 	return nil
 }
 
@@ -170,7 +170,7 @@ func (bnWs *BinanceWs) SubscribeTicker(pair CurrencyPair) error {
 			return errors.New("unknown message " + msgType)
 		}
 	}
-	bnWs.subscribe(endpoint, handle)
+	bnWs.Subscribe(endpoint, handle)
 	return nil
 }
 
@@ -217,7 +217,7 @@ func (bnWs *BinanceWs) SubscribeTrade(pair CurrencyPair) error {
 			return errors.New("unknown message " + msgType)
 		}
 	}
-	bnWs.subscribe(endpoint, handle)
+	bnWs.Subscribe(endpoint, handle)
 	return nil
 }
 
@@ -256,7 +256,7 @@ func (bnWs *BinanceWs) SubscribeKline(pair CurrencyPair, period int) error {
 			return errors.New("unknown message " + msgType)
 		}
 	}
-	bnWs.subscribe(endpoint, handle)
+	bnWs.Subscribe(endpoint, handle)
 	return nil
 }
 
@@ -341,7 +341,7 @@ func (bnWs *BinanceWs) SubscribeAggTrade(pair CurrencyPair, tradeCallback func(*
 			return errors.New("unknown message " + msgType)
 		}
 	}
-	bnWs.subscribe(endpoint, handle)
+	bnWs.Subscribe(endpoint, handle)
 	return nil
 }
 
@@ -380,7 +380,7 @@ func (bnWs *BinanceWs) SubscribeDiffDepth(pair CurrencyPair, depthCallback func(
 		depthCallback((*Depth)(unsafe.Pointer(diffDepth)))
 		return nil
 	}
-	bnWs.subscribe(endpoint, handle)
+	bnWs.Subscribe(endpoint, handle)
 	return nil
 }
 

--- a/binance/BinanceWs_test.go
+++ b/binance/BinanceWs_test.go
@@ -12,6 +12,8 @@ var bnWs = NewBinanceWs()
 
 func init() {
 	bnWs.proxyUrl = "socks5://127.0.0.1:1080"
+	//bnWs.SetBaseUrl("wss://fstream.binancezh.com/ws")
+	//bnWs.SetCombinedBaseURL("wss://fstream.binancezh.com/stream?streams=")
 	bnWs.SetCallbacks(printfTicker, printfDepth, printfTrade, printfKline)
 }
 


### PR DESCRIPTION
修复BinanceWs.SubscribeDepth方法，深度数据解析错误bug，导致没有深度数据
修改方法名：BinanceWs.subscribe->BinanceWs.Subscribe
BinanceWs测试中，增加注释内容wss://fstream.binancezh.com/ws供大家学习使用