### PR TITLE
[bitstamp] Add support for PAX, GBP and XLM

### DIFF
--- a/CurrencyPair.go
+++ b/CurrencyPair.go
@@ -58,6 +58,8 @@ var (
 	HT      = Currency{"HT", "HuoBi Token"}
 	BNB     = Currency{"BNB", "BNB, or Binance Coin, is a cryptocurrency created by Binance."}
 	TRX     = Currency{"TRX", ""}
+	GBP     = Currency{"GBP", ""}
+	XLM     = Currency{"XLM", ""}
 
 	//currency pair
 	BTC_KRW = CurrencyPair{CurrencyA: BTC, CurrencyB: KRW, AmountTickSize: 2, PriceTickSize: 1}

--- a/bitstamp/Bitstamp.go
+++ b/bitstamp/Bitstamp.go
@@ -97,6 +97,21 @@ func (bitstamp *Bitstamp) GetAccount() (*Account, error) {
 		Amount:       ToFloat64(respmap["bch_available"]),
 		ForzenAmount: ToFloat64(respmap["bch_reserved"]),
 		LoanAmount:   0}
+	acc.SubAccounts[GBP] = SubAccount{
+		Currency:     GBP,
+		Amount:       ToFloat64(respmap["gbp_available"]),
+		ForzenAmount: ToFloat64(respmap["gbp_reserved"]),
+		LoanAmount:   0}
+	acc.SubAccounts[PAX] = SubAccount{
+		Currency:     PAX,
+		Amount:       ToFloat64(respmap["pax_available"]),
+		ForzenAmount: ToFloat64(respmap["pax_reserved"]),
+		LoanAmount:   0}
+	acc.SubAccounts[XLM] = SubAccount{
+		Currency:     XLM,
+		Amount:       ToFloat64(respmap["xlm_available"]),
+		ForzenAmount: ToFloat64(respmap["xlm_reserved"]),
+		LoanAmount:   0}
 	return &acc, nil
 }
 


### PR DESCRIPTION
Hey,

I've opened this PR to update currently supported currencies on [Bitstamp](https://www.bitstamp.net/api-internal/market/currencies/).