### PR TITLE
[bithumb] get balances for all currencies

### DIFF
--- a/bithumb/bithumb.go
+++ b/bithumb/bithumb.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -212,36 +213,17 @@ func (bit *Bithumb) GetAccount() (*Account, error) {
 	datamap := retmap["data"].(map[string]interface{})
 	acc := new(Account)
 	acc.SubAccounts = make(map[Currency]SubAccount)
-	acc.SubAccounts[LTC] = SubAccount{
-		Currency:     LTC,
-		Amount:       ToFloat64(datamap["available_ltc"]),
-		ForzenAmount: ToFloat64(datamap["in_use_ltc"]),
-		LoanAmount:   0}
-	acc.SubAccounts[BTC] = SubAccount{
-		Currency:     BTC,
-		Amount:       ToFloat64(datamap["available_btc"]),
-		ForzenAmount: ToFloat64(datamap["in_use_etc"]),
-		LoanAmount:   0}
-	acc.SubAccounts[ETH] = SubAccount{
-		Currency:     ETH,
-		Amount:       ToFloat64(datamap["available_eth"]),
-		ForzenAmount: ToFloat64(datamap["in_use_eth"]),
-		LoanAmount:   0}
-	acc.SubAccounts[ETC] = SubAccount{
-		Currency:     ETC,
-		Amount:       ToFloat64(datamap["available_etc"]),
-		ForzenAmount: ToFloat64(datamap["in_use_etc"]),
-		LoanAmount:   0}
-	acc.SubAccounts[BCH] = SubAccount{
-		Currency:     BCH,
-		Amount:       ToFloat64(datamap["available_bch"]),
-		ForzenAmount: ToFloat64(datamap["in_use_bch"]),
-		LoanAmount:   0}
-	acc.SubAccounts[KRW] = SubAccount{
-		Currency:     KRW,
-		Amount:       ToFloat64(datamap["available_krw"]),
-		ForzenAmount: ToFloat64(datamap["in_use_krw"]),
-		LoanAmount:   0}
+	for key := range datamap {
+		if strings.HasPrefix(key, "available_") {
+			t := strings.Split(key, "_")
+			currency := NewCurrency(strings.ToUpper(t[len(t)-1]), "")
+			acc.SubAccounts[currency] = SubAccount{
+				Currency: currency,
+				Amount: ToFloat64(datamap[key]),
+				ForzenAmount: ToFloat64(datamap[fmt.Sprintf("in_use_%s", strings.ToLower(currency.String()))]),
+				LoanAmount: 0}
+		}
+	}
 	//log.Println(datamap)
 	acc.Exchange = bit.GetExchangeName()
 	return acc, nil


### PR DESCRIPTION
I don't get why `GetAccount()` for bithumb has been implemented to only parse balances of BTC, ETH, ETC, LTC, BCH, KRW.  
Therefore, I have implemented a patch to parse balances for all currencies. Enjoy!