### PR TITLE
supported simulation trading of okx

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,32 +22,52 @@ import (
 
 func main() {
 	logger.SetLevel(logger.DEBUG)                             //设置日志输出级别
-	//goexv2.DefaultHttpCli.SetProxy("socks5://127.0.0.1:1080") //socks代理
+	// goexv2.DefaultHttpCli.SetProxy("socks5://127.0.0.1:8080") //socks代理
 	goexv2.DefaultHttpCli.SetTimeout(5)                       // 5 second
 
 	_, _, err := goexv2.OKx.Spot.GetExchangeInfo() //建议调用
 	if err != nil {
 		panic(err)
 	}
-	btcUSDTCurrencyPair, err := goexv2.OKx.Spot.NewCurrencyPair(model.BTC, model.USDT)//建议这样构建CurrencyPair
+	btcUSDTCurrencyPair, err := goexv2.OKx.Spot.NewCurrencyPair(model.BTC, model.USDT) //建议这样构建CurrencyPair
 	if err != nil {
 		panic(err)
 	}
-		
-	//共有api调用
-	log.Println(goexv2.OKx.Spot.GetTicker(btcUSDTCurrencyPair))
 
-	//私有API调用
+	// 共有api调用，交易对的基本信息
+	log.Println(goexv2.OKx.Spot.GetTicker(btcUSDTCurrencyPair))
+	// 获取当前市场价格
+	klines, _, err := goexv2.OKx.Spot.GetKline(btcUSDTCurrencyPair, model.Kline_1min)
+	if err != nil {
+		panic(err)
+	}
+	priceNow := klines[0].Close
+
+	// 私有API调用
 	okxPrvApi := goexv2.OKx.Spot.NewPrvApi(
-		options.WithApiKey(""), 
-		options.WithApiSecretKey(""), 
-		options.WithPassphrase(""))
+		options.WithApiKey(""),
+		options.WithApiSecretKey(""),
+		options.WithPassphrase(""),
+		options.WithSimulated())
+
+	account, _, err := okxPrvApi.GetAccount()
+	if err != nil {
+		return
+	}
+	log.Println(account)
 	
-	//创建订单
-	order, _, err := okxPrvApi.CreateOrder(btcUSDTCurrencyPair, 0.01, 18000, model.Spot_Buy, model.OrderType_Limit)
+	// 以市场价 0.9倍价格 下买单，不会成交
+	order, _, err := okxPrvApi.CreateOrder(btcUSDTCurrencyPair, 0.01, priceNow*0.9, model.Spot_Buy, model.OrderType_Limit)
 	log.Println(err)
 	log.Println(order)
+	// 撤回订单
+	cancelOrder, err := okxPrvApi.CancelOrder(btcUSDTCurrencyPair, order.Id)
+	if err != nil {
+		panic(err)
+	}
+	log.Println(string(cancelOrder))
 }
+
 ```
 
 ### Thanks

--- a/api.go
+++ b/api.go
@@ -22,9 +22,9 @@ type IPubRest interface {
 	NewCurrencyPair(baseSym, quoteSym string, opts ...model.OptionParameter) (model.CurrencyPair, error)
 }
 
-//IPrvRest is a private interface specification that requires authorization to call.
+// IPrvRest is a private interface specification that requires authorization to call.
 type IPrvRest interface {
-	GetAccount(coin string) (map[string]model.Account, []byte, error)
+	GetAccount(coinList ...string) (map[string]model.Account, []byte, error)
 	//CreateOrder
 	//@returns
 	//  order        包含订单ID信息

--- a/binance/futures/fapi/fapi_prv.go
+++ b/binance/futures/fapi/fapi_prv.go
@@ -17,7 +17,7 @@ type Prv struct {
 	apiOpts options.ApiOptions
 }
 
-func (p *Prv) GetAccount(currency string) (map[string]Account, []byte, error) {
+func (p *Prv) GetAccount(currency ...string) (map[string]Account, []byte, error) {
 	param := &url.Values{}
 	responseBody, err := p.DoAuthRequest(http.MethodGet, p.UriOpts.Endpoint+p.UriOpts.GetAccountUri, param, nil)
 	if err != nil {
@@ -183,6 +183,9 @@ func (p *Prv) GetPositions(pair CurrencyPair, opts ...OptionParameter) (position
 func (p *Prv) DoAuthRequest(method, reqUrl string, params *url.Values, header map[string]string) ([]byte, error) {
 	if header == nil {
 		header = make(map[string]string, 2)
+	}
+	if p.apiOpts.Simulated {
+		return nil, errors.New("Simulation trading is not supported yet")
 	}
 	header["X-MBX-APIKEY"] = p.apiOpts.Key
 	common.SignParams(params, p.apiOpts.Secret)

--- a/binance/spot/prv.go
+++ b/binance/spot/prv.go
@@ -1,6 +1,7 @@
 package spot
 
 import (
+	"errors"
 	"fmt"
 	"github.com/nntaoli-project/goex/v2/binance/common"
 	. "github.com/nntaoli-project/goex/v2/httpcli"
@@ -25,7 +26,7 @@ func NewPrvApi(apiOpts ...options.ApiOption) *PrvApi {
 	return s
 }
 
-func (s *PrvApi) GetAccount(coin string) (map[string]Account, []byte, error) {
+func (s *PrvApi) GetAccount(coinList ...string) (map[string]Account, []byte, error) {
 	//TODO implement me
 	panic("implement me")
 }
@@ -104,6 +105,9 @@ func (s *PrvApi) CancelOrder(pair CurrencyPair, id string, opt ...OptionParamete
 func (s *PrvApi) DoAuthRequest(method, reqUrl string, params *url.Values, header map[string]string) ([]byte, error) {
 	if header == nil {
 		header = make(map[string]string, 2)
+	}
+	if s.apiOpts.Simulated {
+		return nil, errors.New("Simulation trading is not supported yet")
 	}
 	header["X-MBX-APIKEY"] = s.apiOpts.Key
 	common.SignParams(params, s.apiOpts.Secret)

--- a/options/api_options.go
+++ b/options/api_options.go
@@ -5,6 +5,7 @@ type ApiOptions struct {
 	Secret     string
 	Passphrase string
 	ClientId   string
+	Simulated  bool
 }
 
 type ApiOption func(options *ApiOptions)
@@ -30,5 +31,15 @@ func WithPassphrase(passphrase string) ApiOption {
 func WithClientId(clientId string) ApiOption {
 	return func(options *ApiOptions) {
 		options.ClientId = clientId
+	}
+}
+
+func WithSimulated(isSimulated ...bool) ApiOption {
+	return func(options *ApiOptions) {
+		if len(isSimulated) <= 0 {
+			options.Simulated = true
+		} else {
+			options.Simulated = isSimulated[0]
+		}
 	}
 }


### PR DESCRIPTION
You can use OKX's simulated trading by adding `options.WithSimulated()` or `options.WithSimulated(true)` .


```golang
okxPrvApi := goexv2.OKx.Spot.NewPrvApi(
		options.WithApiKey(""),
		options.WithApiSecretKey(""),
		options.WithPassphrase(""),
		options.WithSimulated())
```
