### PR TITLE
refactor: replace interface{} with any

### DIFF
--- a/binance/spot/unmarshaler.go
+++ b/binance/spot/unmarshaler.go
@@ -318,6 +318,6 @@ func (u *RespUnmarshaler) UnmarshalGetExchangeInfoResponse(data []byte) (map[str
 	return currencyPairMap, err
 }
 
-func (u *RespUnmarshaler) UnmarshalResponse(data []byte, res interface{}) error {
+func (u *RespUnmarshaler) UnmarshalResponse(data []byte, res any) error {
 	return json.Unmarshal(data, res)
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -40,60 +40,60 @@ func SetLevel(level LogLevel) {
 	std.SetLevel(logger.Level(level))
 }
 
-func Debug(args ...interface{}) {
+func Debug(args ...any) {
 	std.Output(3, logger.DEBUG, "[DEBUG]", fmt.Sprint(args...))
 }
 
-func Debugf(format string, args ...interface{}) {
+func Debugf(format string, args ...any) {
 	std.Output(3, logger.DEBUG, "[DEBUG]", fmt.Sprintf(format, args...))
 }
 
-func Info(args ...interface{}) {
+func Info(args ...any) {
 	std.Output(3, logger.INFO, "[INFO ]", fmt.Sprint(args...))
 }
 
-func Infof(format string, args ...interface{}) {
+func Infof(format string, args ...any) {
 	std.Output(3, logger.INFO, "[INFO ]", fmt.Sprintf(format, args...))
 }
 
-func Warn(args ...interface{}) {
+func Warn(args ...any) {
 	std.Output(3, logger.WARN, "[WARN ]", fmt.Sprint(args...))
 }
 
-func Warnf(format string, args ...interface{}) {
+func Warnf(format string, args ...any) {
 	std.Output(3, logger.WARN, "[WARN ]", fmt.Sprintf(format, args...))
 }
 
-func Error(args ...interface{}) {
+func Error(args ...any) {
 	std.Output(3, logger.ERROR, "[ERROR]", fmt.Sprint(args...))
 }
 
-func Errorf(format string, args ...interface{}) {
+func Errorf(format string, args ...any) {
 	std.Output(3, logger.ERROR, "[ERROR]", fmt.Sprintf(format, args...))
 }
 
-func Fatal(args ...interface{}) {
+func Fatal(args ...any) {
 	if std.level <= FATAL {
 		std.Output(3, logger.FATAL, "[FATAL]", fmt.Sprint(args...))
 		os.Exit(1)
 	}
 }
 
-func Fatalf(format string, args ...interface{}) {
+func Fatalf(format string, args ...any) {
 	if std.level <= FATAL {
 		std.Output(3, logger.FATAL, "[FATAL]", fmt.Sprintf(format, args...))
 		os.Exit(1)
 	}
 }
 
-func Panic(args ...interface{}) {
+func Panic(args ...any) {
 	if std.level <= PANIC {
 		std.Output(3, logger.PANIC, "[PANIC]", fmt.Sprint(args...))
 		panic("")
 	}
 }
 
-func Panicf(format string, args ...interface{}) {
+func Panicf(format string, args ...any) {
 	if std.level <= PANIC {
 		std.Output(3, logger.PANIC, "[PANIC]", fmt.Sprintf(format, args...))
 		panic("")

--- a/okx/common/unmarshaler.go
+++ b/okx/common/unmarshaler.go
@@ -466,6 +466,6 @@ func (un *RespUnmarshaler) UnmarshalGetLeverageResponse(data []byte) (string, er
 	return jsonparser.GetString(data, "[0]", "lever")
 }
 
-func (un *RespUnmarshaler) UnmarshalResponse(data []byte, res interface{}) error {
+func (un *RespUnmarshaler) UnmarshalResponse(data []byte, res any) error {
 	return json.Unmarshal(data, res)
 }

--- a/options/response_unmarshaler.go
+++ b/options/response_unmarshaler.go
@@ -2,7 +2,7 @@ package options
 
 import "github.com/nntaoli-project/goex/v2/model"
 
-type ResponseUnmarshaler func([]byte, interface{}) error
+type ResponseUnmarshaler func([]byte, any) error
 type GetTickerResponseUnmarshaler func([]byte) (*model.Ticker, error)
 type GetDepthResponseUnmarshaler func([]byte) (*model.Depth, error)
 type GetKlineResponseUnmarshaler func([]byte) ([]model.Kline, error)

--- a/util/utils.go
+++ b/util/utils.go
@@ -33,7 +33,7 @@ func FloatToString(v float64, n int) string {
 //}
 
 func ValuesToJson(v url.Values) ([]byte, error) {
-	paramMap := make(map[string]interface{})
+	paramMap := make(map[string]any)
 	for k, vv := range v {
 		if len(vv) == 1 {
 			paramMap[k] = vv[0]


### PR DESCRIPTION
Replace `interface{}` with `any`. `any` is a type alias for `interface{}` available since Go 1.18. The module already requires go 1.23.